### PR TITLE
osx support

### DIFF
--- a/gridfan
+++ b/gridfan
@@ -85,7 +85,11 @@ f_setup_dev() {
 	fi
 	STTY_PARAMS="4800 raw -echo -echoe -echok"
 	echodebug "${FUNCNAME[0]}: stty setting parameters to the device: \"$STTY_PARAMS\"."
-	stty -F $GRID_DEV $STTY_PARAMS &> /dev/null ; X_STTY=$?
+	if [[ "$OSTYPE" == "darwin"* ]]; then
+		stty -f $GRID_DEV $STTY_PARAMS &> /dev/null ; X_STTY=$?
+	else
+		stty -F $GRID_DEV $STTY_PARAMS &> /dev/null ; X_STTY=$?
+	fi
 	SEEN_SETUP_STTY=1
 	if [[ ! "$X_STTY" == 0 ]] ; then
 		echoerr "ERROR: stty returned code $X_STTY. Unable to set up the serial device file."


### PR DESCRIPTION
Good news - your script works on macOS!

I only had to make a minor modification for the macOS version of stty.

The device file that worked was `/dev/cu.usbmodem1461` (worth putting in readme). Don't really understand at the moment why using `/dev/tty.usbmodem1461` was not working. I haven't investigated a way to set device file permissions on Mac, if even possible. Just used sudo:

```
bash-3.2# sudo ./gridfan -d /dev/cu.usbmodem1461 init

Trying to initialize communications with the controller.

  Please wait:

Success! Controller initialized.

bash-3.2# sudo ./gridfan -d /dev/cu.usbmodem1461 set fans all speed 0

Fan 1 successfully set to 0% speed.
Fan 2 successfully set to 0% speed.
Fan 3 successfully set to 0% speed.
Fan 4 successfully set to 0% speed.
Fan 5 successfully set to 0% speed.
Fan 6 successfully set to 0% speed.

bash-3.2# sudo ./gridfan -d /dev/cu.usbmodem1461 show all

Fan 1: 0 RPM
Fan 2: 0 RPM
Fan 3: 0 RPM
Fan 4: 0 RPM
Fan 5: 0 RPM
Fan 6: 0 RPM
```

Awesome! Nice work, @CapitalF 🍾  🍰  👍